### PR TITLE
Fix RPC Error in omni_createpayload_setnonfungibledata

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -295,8 +295,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "omni_createpayload_sendnonfungible", 1, "tokenstart"},
     { "omni_createpayload_sendnonfungible", 2, "tokenend"},
     { "omni_createpayload_setnonfungibledata", 0, "propertyid"},
-    { "omni_createpayload_setnonfungibledata", 1, "tokenid"},
-    { "omni_createpayload_setnonfungibledata", 2, "issuer"},
+    { "omni_createpayload_setnonfungibledata", 1, "tokenstart"},
+    { "omni_createpayload_setnonfungibledata", 2, "tokenend"},
+    { "omni_createpayload_setnonfungibledata", 3, "issuer"},
 };
 // clang-format on
 


### PR DESCRIPTION
Trying to use `omni_createpayload_setnonfungibledata` with the correct arguments, e.g.

`omni_createpayload_setnonfungibledata 255 1 1 true "data"`

will result in an RPC error complaining that the argument is not a boolean as expected. Invoking the same kind of command with `omni_setnonfungibledata` causes no such error.

The error lies in `src/rpc/client.cpp`, where it turns out the command is missing parameters. Adding these in to match `omni_setnonfungibledata` corrects behavior.